### PR TITLE
task: Add subgraph check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+**Issue:** [XXX-XXX](https://linear.app/sibi/issue/XXX-XXX)
+
+## Changes
+
+- Put itemized changes here.
+
+## Rationale
+
+What was the overarching product goal of this PR.
+
+## Considerations
+
+Why you made some of the technical decisions that you made, especially if the reasoning is not immediately obvious

--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -17,9 +17,6 @@ on:
         required: false
         type: string
         default: exit 0
-      APOLLO_VCS_COMMIT:
-        required: false
-        type: string
     secrets:
       APOLLO_KEY:
         required: true
@@ -30,7 +27,7 @@ jobs:
     environment: apollo
     env:
       APOLLO_KEY: ${{ secrets.APOLLO_STUDIO_KEY }}
-      APOLLO_VCS_COMMIT: ${{ inputs.APOLLO_VCS_COMMIT }}
+      APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -1,0 +1,42 @@
+name: Subgraph Check
+
+on:
+  workflow_call:
+    inputs:
+      graph:
+        required: true
+        type: string
+      variant:
+        required: false
+        type: string
+        default: current
+      schema_path:
+        required: true
+        type: string
+      schema_build_cmd:
+        required: false
+        type: string
+        default: exit 0
+      APOLLO_VCS_COMMIT:
+        required: false
+        type: string
+    secrets:
+      APOLLO_KEY:
+        required: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    environment: apollo
+    env:
+      APOLLO_KEY: ${{ secrets.APOLLO_STUDIO_KEY }}
+      APOLLO_VCS_COMMIT: ${{ inputs.APOLLO_VCS_COMMIT }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Schema
+        run: ${{ inputs.schema_build_cmd }}
+
+      - name:
+        run: npx rover subgraph check ${{ inputs.graph }}@${{ inputs.variant }} --schema ${{ inputs.schema_path }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # workflows
+
 Reusable workflows for CI/CD
+
+### Subgraph Check
+
+Checks a subgraph for breaking changes
+
+```
+jobs:
+  subgraph_check:
+    uses: sibipro/workflows/.github/workflows/subgraph-check.yml@main
+    with:
+      graph: my-federated-graph
+
+      // The path to a single graphql schema file
+      schema_path: ./schema.graphql
+
+      // Optionally pass a command to compile multiple `.graphql` files into a single schema file
+      schema_build_cmd: cat ./graphql/*.graphql > schema.graphql
+
+      // The URL that your gateway uses to communicate with the subgraph in a managed federation architecture.
+      routing_url: http://my-subgraph.com
+    secrets:
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+```


### PR DESCRIPTION
**Issue:** [STO-1599](https://linear.app/sibi/issue/STO-1599)

## Changes

- Create subgraph check workflow

## Rationale

Check if the subgraph has breaking changes before publishing it

## Considerations

1) Rover requires a single schema file, so I exposed an optional `schema_build_cmd`. I expect many services do not compile their schema into a single `.graphql` file and will need this step. 
2) Once this reusable workflow is tested I will create a tag that can be referenced instead of the branch. 