### PR TITLE
chore: Use environment built in rover CLI

### DIFF
--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name:
         run: |
-          npx rover subgraph check ${{ inputs.graph }}@${{ inputs.variant }} \
+          rover subgraph check ${{ inputs.graph }}@${{ inputs.variant }} \
           --schema ${{ inputs.schema_path }} \
           --name ${{ inputs.name }}


### PR DESCRIPTION
## Changes

- Don't use npx to run rovedr

## Rationale

Apollo environment has rover built it
