### PR TITLE
chore: Install rover CLI

### DIFF
--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install Rover
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/v0.1.0 | sh
+          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+
       - name: Build Schema
         run: ${{ inputs.schema_build_cmd }}
 


### PR DESCRIPTION
## Changes

- Install rover CLI

## Rationale

Rover CLI is _not_ installed by default
