### PR TITLE
chore: Use latest rover CLI version

### DIFF
--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.1.0 | sh
+          curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
       - name: Build Schema


### PR DESCRIPTION
## Changes

- Use latest version of rover CLI

## Rationale

Version 0.1.0 has a bug that causes a crash: https://github.com/apollographql/rover/issues/937
