### PR TITLE
chore: Remove VCS commit sha

### DIFF
--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -30,7 +30,6 @@ jobs:
     environment: apollo
     env:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-      APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
## Changes

- Remove deployment sha 

## Rationale

the check does not deploy the schema
