### PR TITLE
feat: rover publish from file

### DIFF
--- a/.github/workflows/subgraph-publish.yml
+++ b/.github/workflows/subgraph-publish.yml
@@ -1,0 +1,49 @@
+name: Subgraph Publish from Files
+
+on:
+  workflow_call:
+    inputs:
+      graph:
+        required: true
+        type: string
+      variant:
+        required: false
+        type: string
+        default: current
+      name:
+        required: true
+        type: string
+      schema_path:
+        required: true
+        type: string
+      schema_build_cmd:
+        required: false
+        type: string
+        default: exit 0
+
+    secrets:
+      APOLLO_KEY:
+        required: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Rover
+        run: |
+          curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+
+      - name: Build Schema
+        run: ${{ inputs.schema_build_cmd }}
+
+      - name: Publish Schema
+        run: |
+          rover subgraph publish ${{ inputs.graph }}@${{ inputs.variant }} \
+          --schema ${{ inputs.schema_path }} \
+          --name ${{ inputs.name }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ jobs:
       APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
 ```
 
+## Subgraph Publish
+
+Publishes a subgraph schema from a file
+
+```yml
+jobs:
+  subgraph_publish:
+    uses: sibipro/workflows/.github/workflows/subgraph-publish.yml@v1.1
+    with:
+      graph: my-federated-graph
+      name: my-subgraph
+      schema_path: ./schema.graphql
+
+      # Optionally pass the graph variant to check against (default: current)
+      variant: current
+
+      # Optionally pass a command to compile multiple `.graphql` files into a single schema file
+      schema_build_cmd: cat ./graphql/*.graphql > schema.graphql
+    secrets:
+      APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
+```
+
 ## Subgraph Publish via Introspection
 
 Publishes a subgraph schema by introspecting the running subgraph.


### PR DESCRIPTION
## Changes

- Added apollo rover publish from a file

## Rationale

We don't always want to use introspection, publishing directly from file is handy because it matches the check workflow, and any failures will stop the deployment, unlike introspection which requires the changes be deployed first.
