### PR TITLE
chore: use the latest version of rover

### DIFF
--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
       - name: Build Schema

--- a/.github/workflows/subgraph-publish-via-introspection.yml
+++ b/.github/workflows/subgraph-publish-via-introspection.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
       - name: Introspect and Publish Schema

--- a/.github/workflows/subgraph-publish.yml
+++ b/.github/workflows/subgraph-publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Rover
         run: |
-          curl -sSL https://rover.apollo.dev/nix/v0.4.1 | sh
+          curl -sSL https://rover.apollo.dev/nix/latest | sh
           echo "$HOME/.rover/bin" >> $GITHUB_PATH
 
       - name: Build Schema


### PR DESCRIPTION
## Changes

- Switch rover install script to use "latest" instead of a pinned version

## Rationale

As I'm converting the PIT services to use the new rover client, I noticed the following message in the output:

> There is a newer version of Rover available: v0.5.4 (currently running v0.4.1)

There's no reason to use an older version, and [the docs](https://www.apollographql.com/docs/rover/getting-started) indicate that you can pull the latest version down by using "latest" as the version. I figured we might as well use the latest until something breaks, at which point we can pin to a specific version as needed.
